### PR TITLE
MAINT: Fix responsiveness for smaller screens

### DIFF
--- a/app/js/components/Workflow.jsx
+++ b/app/js/components/Workflow.jsx
@@ -12,15 +12,23 @@ const Workflow = ({ flow, onClick, disabled }) => (
     <button type="button" disabled={disabled} className="list-group-item"
         style={{ backgroundColor: disabled ? '#f9f9f9' : '' }} onClick={ onClick }
     >
-        <span className={disabled ? 'col-md-3' : 'col-md-7'}>
+        <span className={disabled ? 'col-md-3 col-xs-4' : 'col-md-7 col-sm-6 col-xs-6'}>
             { flow.name }
         </span>
         {disabled ?
-            <span className="col-md-5">
-                {`Requires: ${flow.requires.join(', ')}`}
+            <span className="col-md-5 col-sm-3 col-xs-3">
+                <span className="visible-md-block">
+                  {`Requires: ${flow.requires.join(', ')}`}
+                </span>
+                <span
+                    className="glyphicon glyphicon-warning-sign pull-right
+                               visible-sm-block visible-xs-block"
+                    title={`Requires: ${flow.requires.join(', ')}`}
+                    aria-hidden="true"
+                ></span>
             </span> : null
         }
-        <span className={disabled ? 'col-md-4' : 'col-md-5'}>
+        <span className={disabled ? 'col-md-4 col-xs-5' : 'col-md-5 col-sm-6 col-xs-6'}>
             Produces: { flow.outputs.map(({ type }) => type).join(', ') }
         </span>
     </button>

--- a/app/js/components/Workflow.jsx
+++ b/app/js/components/Workflow.jsx
@@ -12,12 +12,13 @@ const Workflow = ({ flow, onClick, disabled }) => (
     <button type="button" disabled={disabled} className="list-group-item"
         style={{ backgroundColor: disabled ? '#f9f9f9' : '' }} onClick={ onClick }
     >
-        <span className={disabled ? 'col-md-3 col-xs-4' : 'col-md-7 col-sm-6 col-xs-6'}>
+        <span className="col-lg-4 col-md-4 col-sm-5 col-xs-5">
             { flow.name }
         </span>
+        <span className="col-lg-4 col-md-4 col-sm-2 col-xs-2">
         {disabled ?
-            <span className="col-md-5 col-sm-3 col-xs-3">
-                <span className="visible-md-block">
+            <span>
+                <span className="visible-lg-block visible-md-block">
                   {`Requires: ${flow.requires.join(', ')}`}
                 </span>
                 <span
@@ -28,7 +29,8 @@ const Workflow = ({ flow, onClick, disabled }) => (
                 ></span>
             </span> : null
         }
-        <span className={disabled ? 'col-md-4 col-xs-5' : 'col-md-5 col-sm-6 col-xs-6'}>
+        </span>
+        <span className="col-lg-4 col-md-4 col-sm-5 col-xs-5">
             Produces: { flow.outputs.map(({ type }) => type).join(', ') }
         </span>
     </button>

--- a/app/js/components/pages/Job.jsx
+++ b/app/js/components/pages/Job.jsx
@@ -11,12 +11,13 @@ import React from 'react';
 import _ from 'lodash';
 
 
-const Job = ({ plugin, action, inputs, metadata, submitJob, cancelJob, children }) => {
+const Job = ({ action, inputs, metadata, submitJob, cancelJob, children }) => {
     let counter = 1;
     return (
         <div className="container">
             <div className="page-header">
-                <h1>{plugin.name}: {action.description}</h1>
+                <h1>{action.name}</h1>
+                <h4>{action.description}</h4>
             </div>
             <form onSubmit={(e) => submitJob(e, action.parameters)}>
             { action.inputs.map(({ name }) =>
@@ -183,7 +184,6 @@ const Job = ({ plugin, action, inputs, metadata, submitJob, cancelJob, children 
 
 Job.propTypes = {
     inputs: React.PropTypes.object,
-    plugin: React.PropTypes.object,
     action: React.PropTypes.object,
     actionType: React.PropTypes.string,
     children: React.PropTypes.element,

--- a/app/js/containers/Job.js
+++ b/app/js/containers/Job.js
@@ -19,7 +19,6 @@ const mapStateToProps = (state, { params: { pluginId, jobId, actionType, uuid } 
     const action = plugin[actionType].find(w => w.id === jobId);
     const active = state.jobs.activeJobs.find(j => j.uuid === uuid);
     return ({
-        plugin,
         action,
         actionType,
         inputs,


### PR DESCRIPTION
Adjusts display for zoomed in presentations.

This required a bit of tweaking. Just shortening the columns to fit on smaller screens didn't solve the issue as some of our type names are ridiculously long and they would overflow either into the column next to it if in the `Requires` column, or out of the table entirely if in the `Produces` column. Made it a warning glyphicon with the required types as the hover title.

Also resolves #88