### PR TITLE
ENH: new date-based versioning; `qiime` -> `qiime2` package rename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,22 @@ node_js:
 cache:
   directories:
     - node_modules
+before_install:
+    - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+    - chmod +x miniconda.sh
+    - ./miniconda.sh -b
+    - export PATH=/home/travis/miniconda3/bin:$PATH
+install:
+    - conda create --yes -n test-env python=3.5
+    - source activate test-env
+    - pip install https://github.com/qiime2/qiime2/archive/master.zip
+    - pip install flake8
+    - pip install .
+    - git clone https://github.com/qiime2/q2lint
 before_script:
     - export DISPLAY=:99.0; sh -e /etc/init.d/xvfb start
 script:
     - npm test
     - npm run build
+    - flake8
+    - python q2lint/q2lint.py

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,6 @@
-Copyright (c) 2016, QIIME 2 Development Team
+BSD 3-Clause License
+
+Copyright (c) 2016-2017, QIIME 2 development team.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -11,7 +13,7 @@ modification, are permitted provided that the following conditions are met:
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 
-* Neither the name of QIIME, QIIME2Studio, q2studio, nor the names of its
+* Neither the name of the copyright holder nor the names of its
   contributors may be used to endorse or promote products derived from
   this software without specific prior written permission.
 

--- a/app/css/JobHistory.css
+++ b/app/css/JobHistory.css
@@ -1,6 +1,6 @@
 /*
 ----------------------------------------------------------------------------
-Copyright (c) 2016--, QIIME development team.
+Copyright (c) 2016-2017, QIIME 2 development team.
 
 Distributed under the terms of the Modified BSD License.
 

--- a/app/css/JobRunning.css
+++ b/app/css/JobRunning.css
@@ -1,6 +1,6 @@
 /*
 ----------------------------------------------------------------------------
-Copyright (c) 2016--, QIIME development team.
+Copyright (c) 2016-2017, QIIME 2 development team.
 
 Distributed under the terms of the Modified BSD License.
 

--- a/app/css/Loading.css
+++ b/app/css/Loading.css
@@ -1,6 +1,6 @@
 /*
 ----------------------------------------------------------------------------
-Copyright (c) 2016--, QIIME development team.
+Copyright (c) 2016-2017, QIIME 2 development team.
 
 Distributed under the terms of the Modified BSD License.
 

--- a/app/css/Visualization.css
+++ b/app/css/Visualization.css
@@ -1,6 +1,6 @@
 /*
 ----------------------------------------------------------------------------
-Copyright (c) 2016--, QIIME development team.
+Copyright (c) 2016-2017, QIIME 2 development team.
 
 Distributed under the terms of the Modified BSD License.
 

--- a/app/css/main.css
+++ b/app/css/main.css
@@ -1,6 +1,6 @@
 /*
 ----------------------------------------------------------------------------
-Copyright (c) 2016--, QIIME development team.
+Copyright (c) 2016-2017, QIIME 2 development team.
 
 Distributed under the terms of the Modified BSD License.
 

--- a/app/index.html
+++ b/app/index.html
@@ -1,6 +1,6 @@
 <!--
 ----------------------------------------------------------------------------
-Copyright (c) 2016--, QIIME development team.
+Copyright (c) 2016-2017, QIIME 2 development team.
 
 Distributed under the terms of the Modified BSD License.
 

--- a/app/js/actions/artifacts.js
+++ b/app/js/actions/artifacts.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/actions/connection.js
+++ b/app/js/actions/connection.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/actions/currentdirectory.js
+++ b/app/js/actions/currentdirectory.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/actions/index.js
+++ b/app/js/actions/index.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/actions/jobs.js
+++ b/app/js/actions/jobs.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/actions/plugins.js
+++ b/app/js/actions/plugins.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/actions/tabstate.js
+++ b/app/js/actions/tabstate.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/actions/types.js
+++ b/app/js/actions/types.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/actions/windowstate.js
+++ b/app/js/actions/windowstate.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/components/Artifact.jsx
+++ b/app/js/components/Artifact.jsx
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/components/ArtifactDetail.jsx
+++ b/app/js/components/ArtifactDetail.jsx
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/components/ArtifactGenerator.jsx
+++ b/app/js/components/ArtifactGenerator.jsx
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/components/Artifacts.jsx
+++ b/app/js/components/Artifacts.jsx
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/components/ArtifactsListFrame.jsx
+++ b/app/js/components/ArtifactsListFrame.jsx
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/components/Directory.jsx
+++ b/app/js/components/Directory.jsx
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/components/JobHistory.jsx
+++ b/app/js/components/JobHistory.jsx
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/components/JobHistoryData.jsx
+++ b/app/js/components/JobHistoryData.jsx
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/components/JobList.jsx
+++ b/app/js/components/JobList.jsx
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/components/JobListFrame.jsx
+++ b/app/js/components/JobListFrame.jsx
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/components/JobRow.jsx
+++ b/app/js/components/JobRow.jsx
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/components/JobRunning.jsx
+++ b/app/js/components/JobRunning.jsx
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/components/Loading.jsx
+++ b/app/js/components/Loading.jsx
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/components/Metadata.jsx
+++ b/app/js/components/Metadata.jsx
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/components/MetadataFile.jsx
+++ b/app/js/components/MetadataFile.jsx
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/components/Plugins.jsx
+++ b/app/js/components/Plugins.jsx
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/components/Tabs.jsx
+++ b/app/js/components/Tabs.jsx
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/components/Timer.jsx
+++ b/app/js/components/Timer.jsx
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/components/Visualization.jsx
+++ b/app/js/components/Visualization.jsx
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/components/Workflow.jsx
+++ b/app/js/components/Workflow.jsx
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/components/Workflows.jsx
+++ b/app/js/components/Workflows.jsx
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/components/pages/App.jsx
+++ b/app/js/components/pages/App.jsx
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/components/pages/Job.jsx
+++ b/app/js/components/pages/Job.jsx
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/containers/ArtifactDetail.js
+++ b/app/js/containers/ArtifactDetail.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/containers/ArtifactGenerator.js
+++ b/app/js/containers/ArtifactGenerator.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/containers/ArtifactsList.js
+++ b/app/js/containers/ArtifactsList.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/containers/Auth.js
+++ b/app/js/containers/Auth.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/containers/Directory.js
+++ b/app/js/containers/Directory.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/containers/Job.js
+++ b/app/js/containers/Job.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/containers/JobHistory.js
+++ b/app/js/containers/JobHistory.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/containers/JobList.js
+++ b/app/js/containers/JobList.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/containers/Loading.js
+++ b/app/js/containers/Loading.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/containers/PluginsList.js
+++ b/app/js/containers/PluginsList.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/containers/Visualization.js
+++ b/app/js/containers/Visualization.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/containers/Workflows.js
+++ b/app/js/containers/Workflows.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/main.jsx
+++ b/app/js/main.jsx
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/reducers/artifacts.js
+++ b/app/js/reducers/artifacts.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/reducers/connection.js
+++ b/app/js/reducers/connection.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/reducers/currentdirectory.js
+++ b/app/js/reducers/currentdirectory.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/reducers/currentjob.js
+++ b/app/js/reducers/currentjob.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/reducers/index.js
+++ b/app/js/reducers/index.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/reducers/jobs.js
+++ b/app/js/reducers/jobs.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/reducers/plugins.js
+++ b/app/js/reducers/plugins.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/reducers/supertypes.js
+++ b/app/js/reducers/supertypes.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/reducers/tabstate.js
+++ b/app/js/reducers/tabstate.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/reducers/windowState.js
+++ b/app/js/reducers/windowState.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/util/auth.js
+++ b/app/js/util/auth.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/js/util/devtools.js
+++ b/app/js/util/devtools.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/app/main.js
+++ b/app/main.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/config/eslint.yaml
+++ b/config/eslint.yaml
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/config/stylelint.yaml
+++ b/config/stylelint.yaml
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/config/webpack.main.config.js
+++ b/config/webpack.main.config.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/config/webpack.shared.js
+++ b/config/webpack.shared.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "q2studio",
-  "version": "0.0.1",
+  "version": "2017.2.0-dev0",
   "description": "A web-based interface for QIIME 2.",
   "author": "QIIME 2 Development Team",
   "license": "BSD-3-Clause",

--- a/q2studio/__init__.py
+++ b/q2studio/__init__.py
@@ -1,12 +1,15 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+import pkg_resources
+
 from .server import start_server
-__version__ = "0.0.1"
+
+__version__ = pkg_resources.get_distribution('q2studio').version
 
 __all__ = ['start_server']

--- a/q2studio/__main__.py
+++ b/q2studio/__main__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2studio/api/__init__.py
+++ b/q2studio/api/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2studio/api/plugins.py
+++ b/q2studio/api/plugins.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -9,9 +9,9 @@
 import collections
 
 from flask import Blueprint, jsonify, url_for
-import qiime.sdk
+import qiime2.sdk
 
-PLUGIN_MANAGER = qiime.sdk.PluginManager()
+PLUGIN_MANAGER = qiime2.sdk.PluginManager()
 plugins = Blueprint('plugins', __name__)
 
 

--- a/q2studio/api/types.py
+++ b/q2studio/api/types.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -7,18 +7,18 @@
 # ----------------------------------------------------------------------------
 
 from flask import Blueprint, jsonify, request
-import qiime.sdk
+import qiime2.sdk
 
 types = Blueprint('types', __name__)
 
-PLUGIN_MANAGER = qiime.sdk.PluginManager()
+PLUGIN_MANAGER = qiime2.sdk.PluginManager()
 
 
 @types.route('/subtype', methods=['POST'])
 def is_subtype():
     request_body = request.get_json()
-    list_a = list(map(qiime.sdk.parse_type, request_body['a']))
-    list_b = list(map(qiime.sdk.parse_type, request_body['b']))
+    list_a = list(map(qiime2.sdk.parse_type, request_body['a']))
+    list_b = list(map(qiime2.sdk.parse_type, request_body['b']))
 
     yes = {}
     no = {}

--- a/q2studio/api/workspace.py
+++ b/q2studio/api/workspace.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -8,11 +8,10 @@
 
 import os
 import glob
-import tempfile
 
 from flask import Blueprint, jsonify, request, abort, url_for\
 
-from qiime.sdk import Artifact, Visualization
+from qiime2.sdk import Artifact, Visualization
 from ..util import fail_gracefully
 
 workspace = Blueprint('workspace', __name__)
@@ -132,6 +131,7 @@ def inspect_visualization(uuid):
         abort(404)
 
     return jsonify({'uuid': metadata.uuid, 'type': metadata.type})
+
 
 @workspace.route('/visualizations/<uuid>', methods=['DELETE'])
 def delete_visualization(uuid):

--- a/q2studio/headers.py
+++ b/q2studio/headers.py
@@ -1,10 +1,11 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
+
 
 def add_cors_headers(response):
     response.headers.add('Access-Control-Allow-Headers',

--- a/q2studio/security.py
+++ b/q2studio/security.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2studio/server.py
+++ b/q2studio/server.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2studio/util.py
+++ b/q2studio/util.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -13,8 +13,10 @@ with open("README.md") as fh:
 
 setup(
     name='q2studio',
-    version='0.0.1',
+    version='2017.2.0.dev0',
+    license='BSD-3-Clause',
+    url='https://qiime2.org',
     long_description=long_description,
     packages=find_packages(),
-    install_requires=['click', 'flask', 'gevent']
+    install_requires=['click', 'flask', 'gevent', 'qiime2 == 2017.2.*']
 )

--- a/test/reducer_spec.js
+++ b/test/reducer_spec.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------------
-// Copyright (c) 2016--, QIIME development team.
+// Copyright (c) 2016-2017, QIIME 2 development team.
 //
 // Distributed under the terms of the Modified BSD License.
 //


### PR DESCRIPTION
# ~~DO NOT MERGE~~

New date-based versioning scheme is:

- YYYY.M.patch.dev0 for development version (e.g. 2017.2.0.dev0, 2017.2.1.dev0, 2018.10.0.dev0)
- YYYY.M.patch for release version (e.g. 2017.2.0, 2017.2.1, 2018.10.0)

Plugins/interfaces are recommended to specify `qiime2 == YYYY.M.*` in setup.py's `install_requires` to obtain patch releases for a given train release.

The new versioning scheme is PEP 440 compliant.