### PR TITLE
Source format selection

### DIFF
--- a/app/js/components/ArtifactGenerator.jsx
+++ b/app/js/components/ArtifactGenerator.jsx
@@ -22,7 +22,8 @@ const ArtifactGenerator = ({
             <thead>
                 <tr>
                     <th className="col-xs-1" />
-                    <th className="col-xs-5" />
+                    <th className="col-xs-3" />
+                    <th className="col-xs-2" />
                     <th className="col-xs-3" />
                     <th className="col-xs-3" />
                 </tr>
@@ -91,6 +92,14 @@ const ArtifactGenerator = ({
                                 type="text"
                                 className="form-control"
                                 placeholder="Name"
+                            />
+                        </td>
+                        <td style={style}>
+                            <input
+                                name="source_format"
+                                type="text"
+                                className="form-control"
+                                placeholder="Source Format (optional)"
                             />
                         </td>
                         <td style={style}>

--- a/app/js/containers/ArtifactGenerator.js
+++ b/app/js/containers/ArtifactGenerator.js
@@ -24,7 +24,7 @@ const mapDispatchToProps = dispatch => ({
         const fd = new FormData(e.target);
         const data = {};
         for (const [key, value] of fd) {
-            if (value === '' || value === undefined) {
+            if (key !== 'source_format' && (value === '' || value === undefined)) {
                 alert(`${key} must not be blank!`);
                 return false;
             }

--- a/app/js/containers/ArtifactGenerator.js
+++ b/app/js/containers/ArtifactGenerator.js
@@ -24,11 +24,12 @@ const mapDispatchToProps = dispatch => ({
         const fd = new FormData(e.target);
         const data = {};
         for (const [key, value] of fd) {
-            if (key !== 'source_format' && (value === '' || value === undefined)) {
+            if (key === 'source_format' && value === '') {
+                data[key] = null;
+            } else if (value === '' || value === undefined) {
                 alert(`${key} must not be blank!`);
                 return false;
-            }
-            data[key] = value;
+            } else data[key] = value;
         }
         dispatch(actions.createArtifact(data));
         dispatch(actions.changeTab('createArtifact', (idx + 1) % 2));

--- a/q2studio/api/workspace.py
+++ b/q2studio/api/workspace.py
@@ -76,9 +76,12 @@ def get_artifacts():
 @fail_gracefully
 def create_artifact():
     request_body = request.get_json()
+    _format = None
+    if request_body['source_format']:
+        _format = request_body['source_format']
     artifact = Artifact.import_data(request_body['type'],
                                     request_body['path'],
-                                    request_body['source_format'])
+                                    _format)
     path = os.path.join(os.getcwd(), request_body['name'])
     if not path.endswith('.qza'):
         path += '.qza'

--- a/q2studio/api/workspace.py
+++ b/q2studio/api/workspace.py
@@ -47,8 +47,7 @@ def _result_record(metadata, name, route, source_format=None):
         'name': name,
         'uuid': metadata.uuid,
         'type': metadata.type,
-        'uri': url_for(route, uuid=metadata.uuid),
-        'source_format': source_format
+        'uri': url_for(route, uuid=metadata.uuid)
     }
 
 
@@ -76,12 +75,9 @@ def get_artifacts():
 @fail_gracefully
 def create_artifact():
     request_body = request.get_json()
-    _format = None
-    if request_body['source_format']:
-        _format = request_body['source_format']
     artifact = Artifact.import_data(request_body['type'],
                                     request_body['path'],
-                                    _format)
+                                    request_body['source_format'])
     path = os.path.join(os.getcwd(), request_body['name'])
     if not path.endswith('.qza'):
         path += '.qza'
@@ -104,9 +100,7 @@ def inspect_artifact(uuid):
     except Exception:
         abort(404)
 
-    return jsonify({'uuid': metadata.uuid,
-                    'type': metadata.type,
-                    'source_format': metadata.source_format})
+    return jsonify({'uuid': metadata.uuid, 'type': metadata.type})
 
 
 @workspace.route('/artifacts/<uuid>', methods=['DELETE'])
@@ -145,9 +139,7 @@ def inspect_visualization(uuid):
     except Exception:
         abort(404)
 
-    return jsonify({'uuid': metadata.uuid,
-                    'type': metadata.type,
-                    'source_format': metadata.source_format})
+    return jsonify({'uuid': metadata.uuid, 'type': metadata.type})
 
 
 @workspace.route('/visualizations/<uuid>', methods=['DELETE'])

--- a/q2studio/api/workspace.py
+++ b/q2studio/api/workspace.py
@@ -9,7 +9,7 @@
 import os
 import glob
 
-from flask import Blueprint, jsonify, request, abort, url_for\
+from flask import Blueprint, jsonify, request, abort, url_for
 
 from qiime2.sdk import Artifact, Visualization
 from ..util import fail_gracefully
@@ -42,12 +42,13 @@ def change_workspace():
         abort(500)
 
 
-def _result_record(metadata, name, route):
+def _result_record(metadata, name, route, source_format=None):
     return {
         'name': name,
         'uuid': metadata.uuid,
         'type': metadata.type,
-        'uri': url_for(route, uuid=metadata.uuid)
+        'uri': url_for(route, uuid=metadata.uuid),
+        'source_format': source_format
     }
 
 
@@ -76,7 +77,8 @@ def get_artifacts():
 def create_artifact():
     request_body = request.get_json()
     artifact = Artifact.import_data(request_body['type'],
-                                    request_body['path'])
+                                    request_body['path'],
+                                    request_body['source_format'])
     path = os.path.join(os.getcwd(), request_body['name'])
     if not path.endswith('.qza'):
         path += '.qza'
@@ -99,7 +101,9 @@ def inspect_artifact(uuid):
     except Exception:
         abort(404)
 
-    return jsonify({'uuid': metadata.uuid, 'type': metadata.type})
+    return jsonify({'uuid': metadata.uuid,
+                    'type': metadata.type,
+                    'source_format': metadata.source_format})
 
 
 @workspace.route('/artifacts/<uuid>', methods=['DELETE'])
@@ -138,7 +142,9 @@ def inspect_visualization(uuid):
     except Exception:
         abort(404)
 
-    return jsonify({'uuid': metadata.uuid, 'type': metadata.type})
+    return jsonify({'uuid': metadata.uuid,
+                    'type': metadata.type,
+                    'source_format': metadata.source_format})
 
 
 @workspace.route('/visualizations/<uuid>', methods=['DELETE'])

--- a/test/reducer_spec.js
+++ b/test/reducer_spec.js
@@ -43,8 +43,7 @@ describe('reducer', () => {
         const artifact = {
             name: 'table',
             uuid: 'f16ca3d0-fe83-4b1e-8eea-7e35db3f6b0f',
-            type: 'FeatureTable[Frequency]',
-            source_format: 'BIOM'
+            type: 'FeatureTable[Frequency]'
         };
         const action = actions.newArtifact(artifact);
         const state = reducer(undefined, action);

--- a/test/reducer_spec.js
+++ b/test/reducer_spec.js
@@ -43,7 +43,8 @@ describe('reducer', () => {
         const artifact = {
             name: 'table',
             uuid: 'f16ca3d0-fe83-4b1e-8eea-7e35db3f6b0f',
-            type: 'FeatureTable[Frequency]'
+            type: 'FeatureTable[Frequency]',
+            source_format: 'BIOM'
         };
         const action = actions.newArtifact(artifact);
         const state = reducer(undefined, action);


### PR DESCRIPTION
In regard to [issue 75](https://github.com/qiime2/q2studio/issues/75): added optional source format selection.

No change in behavior for `BIOMV210Format` `.biom` files, but now `BIOMV100Format` `.biom` files are allowed if you specify the format as `BIOMV100Format`.

REST API updated to include the key-value pair in the relevant JSON objects.  Note that if the value is null, I put in a null (`None`) value rather than skipping the pair altogether.  If this is not the desired behavior I can easily change the code accordingly.