### PR TITLE
Linux windows file dir picking

### DIFF
--- a/app/js/actions/currentdirectory.js
+++ b/app/js/actions/currentdirectory.js
@@ -74,14 +74,16 @@ export const selectArtifactDirectory = () => {
                 message: 'What would you like to select?',
                 calcelId: 2
             }, (callback) => {
-                if (callback.response === 1) {
+                if (callback.response === 0) {
                     curProps = ['openFile'];
                     curTitle = 'Choose Artifact File';
-                } else if (callback.response === 2) {
+                    remote.dialog.showErrorBox(curTitle);
+                    // dispatch(openSelectArtifactDirectoryDialog());
+                } else if (callback.response === 1) {
                     curProps = ['openDirectory'];
                     curTitle = 'Choose Artifact Directory';
+                    dispatch(openSelectArtifactDirectoryDialog());
                 }
-                dispatch(openSelectArtifactDirectoryDialog());
             });
         } else dispatch(openSelectArtifactDirectoryDialog());
     };

--- a/app/js/actions/currentdirectory.js
+++ b/app/js/actions/currentdirectory.js
@@ -67,24 +67,22 @@ export const selectArtifactDirectory = () => {
         };
         if (process.platform !== 'darwin') {
             // linux or windows
-            remote.dialog.showMessageBox({
+            const callback = remote.dialog.showMessageBox({
                 type: 'question',
                 buttons: ['File', 'Directory', 'Cancel'],
                 title: 'Artifact Selection',
                 message: 'What would you like to select?',
                 calcelId: 2
-            }, (callback) => {
-                remote.dialog.showErrorBox(callback.response);
-                if (callback.response === 0) {
-                    curProps = ['openFile'];
-                    curTitle = 'Choose Artifact File';
-                    dispatch(openSelectArtifactDirectoryDialog());
-                } else if (callback.response === 1) {
-                    curProps = ['openDirectory'];
-                    curTitle = 'Choose Artifact Directory';
-                    dispatch(openSelectArtifactDirectoryDialog());
-                }
             });
+            if (callback === 0) {
+                curProps = ['openFile'];
+                curTitle = 'Choose Artifact File';
+                dispatch(openSelectArtifactDirectoryDialog());
+            } else if (callback === 1) {
+                curProps = ['openDirectory'];
+                curTitle = 'Choose Artifact Directory';
+                dispatch(openSelectArtifactDirectoryDialog());
+            }
         } else dispatch(openSelectArtifactDirectoryDialog());
     };
 };

--- a/app/js/actions/currentdirectory.js
+++ b/app/js/actions/currentdirectory.js
@@ -52,10 +52,27 @@ const setArtifactDir = path => ({
 export const selectArtifactDirectory = () => {
     return (dispatch, getState) => {
         const currPath = getState().currentDirectory;
+        let props = ['openFile', 'openDirectory'];
+        if (process.platform !== 'darwin') {
+            // linux or windows
+            remote.dialog.showMessageBox({
+                type: 'question',
+                buttons: ['File', 'Directory', 'Cancel'],
+                title: 'Artifact Selection',
+                message: 'What would you like to select?',
+                calcelId: 2
+            }, (callback) => {
+                if (callback.response === 0) {
+                    props = ['openFile'];
+                } else if (callback.response === 1) {
+                    props = ['openDirectory'];
+                }
+            });
+        }
         remote.dialog.showOpenDialog({
             title: 'Choose Artifact Directory or File',
             defaultpath: currPath,
-            properties: ['openFile', 'openDirectory']
+            properties: props
         }, (fps) => {
             if (fps) {
                 dispatch(setArtifactDir(fps[0]));

--- a/app/js/actions/currentdirectory.js
+++ b/app/js/actions/currentdirectory.js
@@ -74,11 +74,11 @@ export const selectArtifactDirectory = () => {
                 message: 'What would you like to select?',
                 calcelId: 2
             }, (callback) => {
+                remote.dialog.showErrorBox(callback.response);
                 if (callback.response === 0) {
                     curProps = ['openFile'];
                     curTitle = 'Choose Artifact File';
-                    remote.dialog.showErrorBox(curTitle);
-                    // dispatch(openSelectArtifactDirectoryDialog());
+                    dispatch(openSelectArtifactDirectoryDialog());
                 } else if (callback.response === 1) {
                     curProps = ['openDirectory'];
                     curTitle = 'Choose Artifact Directory';

--- a/app/js/actions/currentdirectory.js
+++ b/app/js/actions/currentdirectory.js
@@ -52,7 +52,19 @@ const setArtifactDir = path => ({
 export const selectArtifactDirectory = () => {
     return (dispatch, getState) => {
         const currPath = getState().currentDirectory;
-        let props = ['openFile', 'openDirectory'];
+        let curProps = ['openFile', 'openDirectory'];
+        let curTitle = 'Choose Artifact Directory or File';
+        const openSelectArtifactDirectoryDialog = () => {
+            remote.dialog.showOpenDialog({
+                title: curTitle,
+                defaultpath: currPath,
+                properties: curProps
+            }, (fps) => {
+                if (fps) {
+                    dispatch(setArtifactDir(fps[0]));
+                }
+            });
+        };
         if (process.platform !== 'darwin') {
             // linux or windows
             remote.dialog.showMessageBox({
@@ -63,20 +75,14 @@ export const selectArtifactDirectory = () => {
                 calcelId: 2
             }, (callback) => {
                 if (callback.response === 0) {
-                    props = ['openFile'];
+                    curProps = ['openFile'];
+                    curTitle = 'Choose Artifact File';
                 } else if (callback.response === 1) {
-                    props = ['openDirectory'];
+                    curProps = ['openDirectory'];
+                    curTitle = 'Choose Artifact Directory';
                 }
+                dispatch(openSelectArtifactDirectoryDialog());
             });
-        }
-        remote.dialog.showOpenDialog({
-            title: 'Choose Artifact Directory or File',
-            defaultpath: currPath,
-            properties: props
-        }, (fps) => {
-            if (fps) {
-                dispatch(setArtifactDir(fps[0]));
-            }
-        });
+        } else dispatch(openSelectArtifactDirectoryDialog());
     };
 };

--- a/app/js/actions/currentdirectory.js
+++ b/app/js/actions/currentdirectory.js
@@ -74,10 +74,10 @@ export const selectArtifactDirectory = () => {
                 message: 'What would you like to select?',
                 calcelId: 2
             }, (callback) => {
-                if (callback.response === 0) {
+                if (callback.response === 1) {
                     curProps = ['openFile'];
                     curTitle = 'Choose Artifact File';
-                } else if (callback.response === 1) {
+                } else if (callback.response === 2) {
                     curProps = ['openDirectory'];
                     curTitle = 'Choose Artifact Directory';
                 }

--- a/app/js/actions/currentdirectory.js
+++ b/app/js/actions/currentdirectory.js
@@ -53,7 +53,7 @@ export const selectArtifactDirectory = () => {
     return (dispatch, getState) => {
         const currPath = getState().currentDirectory;
         let curProps = ['openFile', 'openDirectory'];
-        let curTitle = 'Choose Artifact Directory or File';
+        let curTitle = 'Choose Directory or File to Import';
         const openSelectArtifactDirectoryDialog = () => {
             remote.dialog.showOpenDialog({
                 title: curTitle,
@@ -67,20 +67,20 @@ export const selectArtifactDirectory = () => {
         };
         if (process.platform !== 'darwin') {
             // linux or windows
-            const callback = remote.dialog.showMessageBox({
+            const response = remote.dialog.showMessageBox({
                 type: 'question',
                 buttons: ['File', 'Directory', 'Cancel'],
                 title: 'Artifact Selection',
-                message: 'What would you like to select?',
+                message: 'Are you importing a single file or directory?',
                 calcelId: 2
             });
-            if (callback === 0) {
+            if (response === 0) {
                 curProps = ['openFile'];
-                curTitle = 'Choose Artifact File';
+                curTitle = 'Choose File to Import';
                 dispatch(openSelectArtifactDirectoryDialog());
-            } else if (callback === 1) {
+            } else if (response === 1) {
                 curProps = ['openDirectory'];
-                curTitle = 'Choose Artifact Directory';
+                curTitle = 'Choose Directory to Import';
                 dispatch(openSelectArtifactDirectoryDialog());
             }
         } else dispatch(openSelectArtifactDirectoryDialog());

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,5 @@ setup(
     url='https://qiime2.org',
     long_description=long_description,
     packages=find_packages(),
-    install_requires=['click', 'flask', 'gevent', 'qiime2 >= 2017.5.*']
+    install_requires=['click', 'flask', 'gevent', 'qiime2 == 2017.5.*']
 )

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,5 @@ setup(
     url='https://qiime2.org',
     long_description=long_description,
     packages=find_packages(),
-    install_requires=['click', 'flask', 'gevent', 'qiime2 == 2017.5.*']
+    install_requires=['click', 'flask', 'gevent', 'qiime2 >= 2017.5.*']
 )


### PR DESCRIPTION
In response to [issue 107](https://github.com/qiime2/q2studio/issues/107).

Functionality remains the same on mac os:

1. `------------------------`
<img width="752" alt="macos_1" src="https://cloud.githubusercontent.com/assets/4683443/26226830/70188d78-3be3-11e7-8771-003d302f42f6.png">

2. `------------------------`
<img width="968" alt="macos_2" src="https://cloud.githubusercontent.com/assets/4683443/26226833/734116d2-3be3-11e7-9d0f-59029096ec8a.png">

3. `------------------------`
<img width="951" alt="macos_3" src="https://cloud.githubusercontent.com/assets/4683443/26226836/76084084-3be3-11e7-9649-9035eae4db34.png">

However, Linux and Windows users should now have the ability to choose to either select a file or a directory.  Previously they could only select directories, since on both OS's file choosers must be one or the other and default to directory when both options are passed.  Demo on the latest Ubuntu in VirtualBox:

First, the user clicks `Import`.  A dialog occurs asking if they would like to select a directory or a file (or cancel altogether).
![linux_1](https://cloud.githubusercontent.com/assets/4683443/26226873/bed08cea-3be3-11e7-8111-4dcefb5518e4.png)
The user selects File.
![linux_2](https://cloud.githubusercontent.com/assets/4683443/26226895/db8f4074-3be3-11e7-8714-6ae456da67eb.png)
The file is successfully imported.
![linux_3](https://cloud.githubusercontent.com/assets/4683443/26226905/eee5a794-3be3-11e7-88e1-f018daab8534.png)
Next, the user clicks `Import` again, and this time chooses directory.  They navigate to the same directory as before, but this time they can't click on the file, only the directory, as below:
![virtualbox_test machine_18_05_2017_15_05_06](https://cloud.githubusercontent.com/assets/4683443/26226923/1040e390-3be4-11e7-9534-d00106d62419.png)
(Notice that the titles on the choose windows change to say Choose Artifact Directory or Choose Artifact File contextually).  The user clicks on the directory, fills in the parameters and clicks Go!.  Success:
![linux_4](https://cloud.githubusercontent.com/assets/4683443/26226948/2f767414-3be4-11e7-9f50-2b44a35a0c6d.png)

Untested on Windows, but it should work according to all the available documentation.  (We don't yet support windows so this shouldn't matter too much for now anyway).