### PR TITLE
ENH: Add importable_formats support, fixes #115

### DIFF
--- a/app/js/actions/artifacts.js
+++ b/app/js/actions/artifacts.js
@@ -119,8 +119,7 @@ export const refreshArtifacts = () => {
         .then((json) => {
             json.artifacts.forEach(artifact => dispatch(newArtifact(artifact)));
         })
-        .then(() => dispatch(actions.checkTypes()))
-        .then(() => dispatch(actions.checkImportableTypes()));
+        .then(() => dispatch(actions.checkTypes()));
     };
 };
 

--- a/app/js/actions/connection.js
+++ b/app/js/actions/connection.js
@@ -24,5 +24,6 @@ export const establishConnection = (uri, secretKey) => {
         dispatch(actions.loadPlugins());
         dispatch(actions.directoryChange(remote.app.getPath('home')));
         dispatch(actions.checkImportableTypes());
+        dispatch(actions.checkImportableFormats());
     };
 };

--- a/app/js/actions/formats.js
+++ b/app/js/actions/formats.js
@@ -1,0 +1,26 @@
+// ----------------------------------------------------------------------------
+// Copyright (c) 2016-2017, QIIME 2 development team.
+//
+// Distributed under the terms of the Modified BSD License.
+//
+// The full license is in the file LICENSE, distributed with this software.
+// ----------------------------------------------------------------------------
+
+import { fetchAPI } from '../util/auth';
+
+export const importFormats = importableFormatsList => ({
+    type: 'IMPORTABLE_FORMATS',
+    importableFormatsList
+});
+
+export const checkImportableFormats = () => {
+    return (dispatch, getState) => {
+        const {
+            connection: { uri, secretKey }
+        } = getState();
+        const url = `http://${uri}/api/formats/importable`;
+        // TODO: don't hit the server if there is nothing new to ask...
+        fetchAPI(secretKey, 'POST', url)
+        .then(json => dispatch(importFormats(json)));
+    };
+};

--- a/app/js/actions/index.js
+++ b/app/js/actions/index.js
@@ -13,6 +13,7 @@ import * as connectionActionCreators from './connection';
 import * as currentDirectoryActionCreators from './currentdirectory';
 import * as tabActionCreators from './tabstate';
 import * as typeActionCreators from './types';
+import * as formatActionCreators from './formats';
 import * as windowStateActionCreators from './windowstate';
 
 const actions = {
@@ -23,6 +24,7 @@ const actions = {
     ...currentDirectoryActionCreators,
     ...tabActionCreators,
     ...typeActionCreators,
+    ...formatActionCreators,
     ...windowStateActionCreators
 };
 

--- a/app/js/components/ArtifactGenerator.jsx
+++ b/app/js/components/ArtifactGenerator.jsx
@@ -17,6 +17,7 @@ const ArtifactGenerator = ({
     createArtifact,
     selectDirectory,
     importableTypes,
+    importableFormats,
     sysPath
 }) => (
     <form onSubmit={e => createArtifact(e, active)}>
@@ -97,11 +98,10 @@ const ArtifactGenerator = ({
                             />
                         </td>
                         <td style={style}>
-                            <input
+                            <ReactSelect
                                 name="source_format"
-                                type="text"
-                                className="form-control"
                                 placeholder="Source Format (optional)"
+                                options={importableFormats}
                             />
                         </td>
                         <td style={style}>
@@ -130,6 +130,7 @@ ArtifactGenerator.propTypes = {
     active: React.PropTypes.number,
     toggleCreation: React.PropTypes.func,
     importableTypes: React.PropTypes.array,
+    importableFormats: React.PropTypes.array,
     sysPath: React.PropTypes.string,
     selectDirectory: React.PropTypes.func,
     createArtifact: React.PropTypes.func

--- a/app/js/containers/ArtifactGenerator.js
+++ b/app/js/containers/ArtifactGenerator.js
@@ -14,6 +14,7 @@ import ArtifactGenerator from '../components/ArtifactGenerator';
 const mapStateToProps = ({ tabState: { createArtifact: { currentIndex } }, ...state }) => ({
     sysPath: state.artifacts.sysCreationPath,
     importableTypes: state.superTypes.importableTypes,
+    importableFormats: state.superTypes.importableFormats,
     active: currentIndex
 });
 

--- a/app/js/reducers/supertypes.js
+++ b/app/js/reducers/supertypes.js
@@ -50,7 +50,7 @@ const reducer = (state = initialState, action) => {
     case 'IMPORTABLE_TYPES': {
         const newState = {
             ...state,
-            importableTypes: action.importableTypesList.map(
+            importableTypes: action.importableTypesList.sort().map(
                 item => ({ value: item, label: item })
             )
         };
@@ -59,7 +59,7 @@ const reducer = (state = initialState, action) => {
     case 'IMPORTABLE_FORMATS': {
         const newState = {
             ...state,
-            importableFormats: action.importableFormatsList.map(
+            importableFormats: action.importableFormatsList.sort().map(
                 item => ({ value: item, label: item })
             )
         };

--- a/app/js/reducers/supertypes.js
+++ b/app/js/reducers/supertypes.js
@@ -9,6 +9,7 @@
 const initialState = {
     knownTypes: new Set(),
     importableTypes: [],
+    importableFormats: [],
     yes: {},
     no: {}
 };
@@ -50,6 +51,15 @@ const reducer = (state = initialState, action) => {
         const newState = {
             ...state,
             importableTypes: action.importableTypesList.map(
+                item => ({ value: item, label: item })
+            )
+        };
+        return newState;
+    }
+    case 'IMPORTABLE_FORMATS': {
+        const newState = {
+            ...state,
+            importableFormats: action.importableFormatsList.map(
                 item => ({ value: item, label: item })
             )
         };

--- a/q2studio/api/formats.py
+++ b/q2studio/api/formats.py
@@ -6,10 +6,16 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from .jobs import jobs
-from .plugins import plugins
-from .types import types
-from .formats import formats
-from .workspace import workspace
+from flask import Blueprint, jsonify
+import qiime2.sdk
 
-__all__ = ['jobs', 'plugins', 'types', 'formats', 'workspace']
+formats = Blueprint('formats', __name__)
+
+PLUGIN_MANAGER = qiime2.sdk.PluginManager()
+
+
+@formats.route('/importable', methods=['POST'])
+def get_importable_formats():
+    ret = [repr(t) for t in PLUGIN_MANAGER.importable_formats]
+    print(ret)
+    return jsonify(ret)

--- a/q2studio/api/formats.py
+++ b/q2studio/api/formats.py
@@ -16,6 +16,5 @@ PLUGIN_MANAGER = qiime2.sdk.PluginManager()
 
 @formats.route('/importable', methods=['POST'])
 def get_importable_formats():
-    ret = [repr(t) for t in PLUGIN_MANAGER.importable_formats]
-    print(ret)
+    ret = [t.format.__name__ for t in PLUGIN_MANAGER.importable_formats]
     return jsonify(ret)

--- a/q2studio/server.py
+++ b/q2studio/server.py
@@ -13,7 +13,7 @@ import base64
 from flask import Flask
 from gevent.pywsgi import WSGIServer
 
-from q2studio.api import jobs, plugins, types, workspace
+from q2studio.api import jobs, plugins, types, formats, workspace
 from q2studio.security import validate_request_authentication
 from q2studio.headers import add_cors_headers
 
@@ -21,6 +21,7 @@ studio = Flask('q2studio')
 studio.register_blueprint(jobs, url_prefix='/api/jobs')
 studio.register_blueprint(plugins, url_prefix='/api/plugins')
 studio.register_blueprint(types, url_prefix='/api/types')
+studio.register_blueprint(formats, url_prefix='/api/formats')
 studio.register_blueprint(workspace, url_prefix='/api/workspace')
 
 studio.before_request(validate_request_authentication)


### PR DESCRIPTION
This PR fixes #115 .  This PR is contingent on other PRs which have not yet been merged:

1. [My PR with @Kleptobismol for QIIME2](https://github.com/qiime2/qiime2/pull/275)
~2. [MY PR with @Kleptobismol for Q2CLI](https://github.com/qiime2/q2cli/pull/138)~

~The above PR's should be reviewed and merged as they are ordered above before this PR can be addressed.  Note that until both 1. and 2. are merged Travis will say that this code fails.~

Travis will fail until https://github.com/qiime2/qiime2/pull/275 is merged.

> (Borders in below screenshots are added to increase readability, as in the past I've found sometimes the screenshots confusingly blend into one another.)

The behavior is effectively the same as that of the `source_types` PR, just for `source_formats`:

1. The user clicks on the `Source Format` select box.  It shows a default value as per **status quo**.
<img width="951" alt="step_1" src="https://cloud.githubusercontent.com/assets/4683443/26748342/aafa909c-47b1-11e7-8fc7-60330c8d6ed6.png">

2. The user begins to type; auto-completion works as expected.
<img width="219" alt="step_2" src="https://cloud.githubusercontent.com/assets/4683443/26748352/c819e484-47b1-11e7-9a20-81dfe25dc8aa.png">

3. The user can click, arrow-key-navigate and return/enter, or simply type to put in their desired value.
<img width="936" alt="screenshot 2017-06-02 16 30 01" src="https://cloud.githubusercontent.com/assets/4683443/26748365/f5e37b64-47b1-11e7-96c9-659a30c22d90.png">

Additionally, I removed a redundant and unnecessary `checkImportableTypes()` call in `app/js/actions/artifacts/js`.