### PR TITLE
BUG: optional artifacts no longer required

### DIFF
--- a/app/js/actions/types.js
+++ b/app/js/actions/types.js
@@ -45,12 +45,14 @@ export const refreshValidation = () => {
             plugin.methods.forEach((method) => {
                 dispatch(missingTypes(plugin.name, 'methods', method,
                     method.inputs.filter(input =>
-                        !artifacts.find(({ type }) => yes[input.type].has(type)))));
+                        input.required && !artifacts.find(({ type }) => yes[input.type].has(type))
+                    )));
             });
             plugin.visualizers.forEach((visualizer) => {
                 dispatch(missingTypes(plugin.name, 'visualizers', visualizer,
                       visualizer.inputs.filter(input =>
-                          !artifacts.find(({ type }) => yes[input.type].has(type)))));
+                          input.required && !artifacts.find(({ type }) => yes[input.type].has(type))
+                      )));
             });
         });
     };

--- a/app/js/components/Workflows.jsx
+++ b/app/js/components/Workflows.jsx
@@ -12,7 +12,7 @@ import Workflow from './Workflow';
 
 const Workflows = ({ plugin, listing, openWorkflow }) => (
     <div>
-        { [...listing].sort((a, b) => a.name > b.name).map(action => (
+        { listing.map(action => (
             <Workflow
                 key={action.name}
                 flow={action}


### PR DESCRIPTION
Confirmed that this works by modifying the `dummy_plugin` on the framework. The optional artifacts no longer have any bearing on whether the action is enabled/disabled.