### PR TITLE
 Update for flake8 v3.6

### DIFF
--- a/q2studio/api/jobs.py
+++ b/q2studio/api/jobs.py
@@ -140,7 +140,7 @@ def create_job():
     stdout = tempfile.TemporaryFile(prefix='q2studio-stdout')
     stderr = tempfile.TemporaryFile(prefix='q2studio-stderr')
     with redirected_stdio(stdout=stdout, stderr=stderr):
-        future = action.async(**inputs)
+        future = action.asynchronous(**inputs)
         future.add_done_callback(
             _callback_factory(job_id, outputs, stdout, stderr))
     return jsonify({


### PR DESCRIPTION
Changes 'async' to 'asynchronous' for pep8 compliance, as discussed in https://github.com/qiime2/qiime2/pull/415

Flake8 v3.6 found no other linting errors.