### PR TITLE
Fix build failure resulting from qiime2 pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,5 @@ setup(
     url='https://qiime2.org',
     long_description=long_description,
     packages=find_packages(),
-    install_requires=['click', 'flask', 'gevent', 'qiime2 == 2020.2.*']
+    install_requires=['click', 'flask', 'gevent']
 )


### PR DESCRIPTION
The version of qiime2 pinned in setup.py conflicts with the version that `pip install git+https://github.com/qiime2/qiime2.git` gets (`qiime2-2020.5.0.dev0+5.g6a5739d`).  I'm not sure if this is the correct way to fix this.  Locally, I got around this by putting `click`, `flask`, and `gevent` in a requirements.txt, then installing `q2studio` via `pip install --no-deps -e .`